### PR TITLE
Change Facebook short token to long lived token

### DIFF
--- a/application/controllers/Account.php
+++ b/application/controllers/Account.php
@@ -22,10 +22,10 @@ class Account extends MY_Controller {
                 'default_graph_version' => $this->config->item('api_version')
             ]);
 
-            $accessToken = $this->accountlib->get_facebook_access_token();
+            $longLivedAccessToken = $this->accountlib->get_facebook_access_token();
 
-            if ($accessToken !== NULL) {
-                $fb->setDefaultAccessToken($accessToken);
+            if ($longLivedAccessToken !== NULL) {
+                $fb->setDefaultAccessToken($longLivedAccessToken);
                 $response = $fb->get('/me?fields=id,name,picture.type(large),email');
                 $userNode = $response->getGraphUser();
                 $data['email'] = $userNode->getEmail();

--- a/application/libraries/Accountlib.php
+++ b/application/libraries/Accountlib.php
@@ -84,7 +84,12 @@ class Accountlib {
     }
 
     public function get_facebook_access_token() {
-        return $this->CI->session->userdata('facebook_access_token');
+        $longLivedToken = $this->CI->session->userdata('facebook_access_token');
+
+        if ($longLivedToken->isExpired()) {
+            return null;
+        }
+        return $longLivedToken;
     }
 
     public function set_profile_image($profile_image) {


### PR DESCRIPTION
마찬가지로 첫 푸쉬이후 많은 커밋이 생겨.. 브랜치를 새로 생성하였습니다.

--

현재 Facebook access token을 account controller의 signup method와 usersapi controller의 register method 두군데서 사용하고 있는데 세션에 따로 저장하지 않고 필요할 때 마다 js에서 받아와 사용하려고 했습니다.

그런데 js에서 access token을 가져오는게 아니라 인증코드? 를 받아오고 이를 통해 access token을 가져오는것 같아서 확인해보니 하나의 인증코드로는 하나의 access token만을 발급받을 수 있는것 같아서.. long lived token으로 변경해 세션에 저장해두는걸로 구현하였습니다.

 #304 의 This authorization code has been used error가 js에서 access token을 두번 가져오려고 할때 발생하는 에러인것 같습니다.

--

남우님이 얘기해 주신대로 longlivedtoken에 대한 테스트는 완료 하였습니다.

향후 FB access token이 언제 또 사용될지 생각해보았습니다.
기획엔 없지만 아마 전시내용이나 작품을 페이스북 타임라인에 공유하기 정도로 사용될 것 같은데,

세션에서 토큰을 가져올때 라이브러리에서 만료된 토큰일 경우 null을 반환하고
이를 사용하는 비즈니스 로직에서 토큰이 없을경우 페이스북 로그인을 하게 만드는게 좋을 것 같아서 일단 null을 반환하는 정도로 수정하였습니다.

현재 세션 유지 시간은
CI 세션 유지 시간 (2시간) / 페이스북 LongLivedToken의 유지 시간 (2개월) 입니다.